### PR TITLE
Update link URLs on the home page

### DIFF
--- a/pages/home.html
+++ b/pages/home.html
@@ -26,7 +26,7 @@
                 <i class="fa fa-puzzle-piece fa-4x"></i>
                 <h3>Extensible</h3>
                 <p>CBT modules extend the core functionality to provide advanced MSBuild functionality such as versioning, signing, and much more.</p>
-                <a href="https://github.com/CommonBuildToolset" class="btn btn-outline btn-md">Browse Modules »</a>
+                <a href="https://github.com/CommonBuildToolset/CBT.Modules" class="btn btn-outline btn-md">Browse Modules »</a>
             </div>
             <div class="col-sm-4">
                 <i class="fa fa-line-chart fa-4x"></i>

--- a/pages/home.html
+++ b/pages/home.html
@@ -20,7 +20,7 @@
                 <i class="fa fa-rocket fa-4x"></i>
                 <h3>Light weight</h3>
                 <p>CBT ships as just three files to include in your code base.  Converting existing projects involves including one import.</p>
-                <a href="https://github.com/CommonBuildToolset" class="btn btn-outline btn-md">Get started »</a>
+                <a href="#/getting-started" class="btn btn-outline btn-md">Get started »</a>
             </div>
             <div class="col-sm-4">
                 <i class="fa fa-puzzle-piece fa-4x"></i>


### PR DESCRIPTION
I think it makes sense for the Get Started link under the "Light weight" section to point to the getting started page instead of the Github repo page. This make the behavior consistent with what the other Get Started links on the page do.